### PR TITLE
Kill Worker If Redis Connection/Job Fetch Fails Repeatedly

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,5 +1,4 @@
-use std::{collections::HashSet, env};
-
+use std::{collections::HashSet, env, thread, time};
 use anyhow::{anyhow, Result};
 use log::error;
 use redis_work_queue::{Item, KeyPrefix, WorkQueue};
@@ -46,8 +45,7 @@ pub async fn main() -> Result<()> {
         env::var("PINGS_REMOVE_ROUTE").expect("PINGS_REMOVE_ROUTE must be set"),
     )?;
 
-    work_loop(queue, db_pool, pings).await?;
-    Ok(())
+    work_loop(queue, db_pool, pings).await
 }
 
 async fn get_simple_data(
@@ -263,15 +261,24 @@ pub async fn work_loop(
     db_pool: Pool<Postgres>,
     pings: PingClient,
 ) -> Result<()> {
+    let mut queue_connect_failure = 0;
+    let three_sec = time::Duration::from_secs(3);
     loop {
         // Wait for a job with no timeout and a lease time of 5 seconds.
         let job: Item = match queue.get_job().await {
             Ok(job) => job,
             Err(err) => {
                 error!("Failed to Get Job: {}", err);
+                queue_connect_failure += 1;
+                thread::sleep(three_sec);
+                if queue_connect_failure >= 3 {
+                    error!("Failed to Fetch Job 3+ Times! Failing...");
+                    return Err(anyhow!("Fetch Job Failed 3 Times. Is Redis Running?"));
+                }
                 continue;
             }
         };
+        queue_connect_failure = 0;
         match work(&job, &db_pool, &pings, &mut queue).await {
             // Mark successful jobs as complete
             Ok(()) => {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -268,7 +268,7 @@ pub async fn work_loop(
         let job: Item = match queue.get_job().await {
             Ok(job) => job,
             Err(err) => {
-                error!("{}", err);
+                error!("Failed to Get Job: {}", err);
                 continue;
             }
         };
@@ -279,11 +279,11 @@ pub async fn work_loop(
             }
             // Drop a job that should be retried - it will be returned to the work queue after
             // the (5 second) lease expires.
-            Err(err) if err.should_retry => error!("{}", err.msg),
+            Err(err) if err.should_retry => error!("Job Failed: {}, Retrying", err.msg),
             // Errors that shouldn't cause a retry should mark the job as complete so it isn't
             // tried again.
             Err(err) => {
-                error!("{}", err.msg);
+                error!("Job Failed: {}, Not Retrying", err.msg);
                 queue.complete(&job).await?;
             }
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashSet, env, thread, time};
 use anyhow::{anyhow, Result};
 use log::error;
 use redis_work_queue::{Item, KeyPrefix, WorkQueue};
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
+use std::{collections::HashSet, env, thread, time};
 
 use crate::{
     app::{RedisJob, SimpleRiderChange},


### PR DESCRIPTION
Currently, if the redis connection dies, the logs will get flooded with Broken Pipe errors. The only way to fix is to manually reset the pod

This PR:

- Adds better logging prefixes so you can more easily find the line failing
- Sleep 3s if the redis connection fails
- Kill the pod if 3+ Redis Connection Failures

Test Plan:

- Run updated code worker
- Kill redis pod
- Observe failure process in logs
<img width="843" alt="image" src="https://github.com/user-attachments/assets/61feb46a-60e1-4378-8603-169ff3b7f071" />
